### PR TITLE
Dockerfile.devにesbuildとtailwindcssをインストールするコマンドを追加しました

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,6 +10,9 @@ RUN apt-get update -qq \
 && wget --quiet -O - /tmp/pubkey.gpg https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs yarn vim
+
+RUN yarn global add esbuild tailwindcss
+
 RUN mkdir /myapp
 WORKDIR /myapp
 RUN gem install bundler


### PR DESCRIPTION
`docker compose up` コマンドにてコンテナの起動時に、tailwindcssなどが見つからないことからコンテナが強制的に落ちてしまうため、変更内容の修正を加えました。
前述の内容の実施後、コンテナ内で`yarn install` の実行でHotwireやDaisyUIなどの依存関係をインストールすることで、無事ローカル環境での動作を確認しました。