### PR TITLE
fix: server error

### DIFF
--- a/app/controllers/_x_users_controller.rb
+++ b/app/controllers/_x_users_controller.rb
@@ -1,3 +1,0 @@
-# class UsersController < ApplicationController
-#   def new; end
-# end


### PR DESCRIPTION
エラー原因の削除
/usr/local/bundle/ruby/3.3.0/gems/zeitwerk-2.6.17/lib/zeitwerk/loader/callbacks.rb:32:in `on_file_autoloaded': expected file /rails/app/controllers/_x_users_controller.rb to define constant XUsersController, but didn't (Zeitwerk::NameError)